### PR TITLE
Toolbox lib & provisioning command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
         "psr-4": {
             "KickAss\\Commerce\\": "src/Commerce",
             "KickAss\\Authentication\\": "src/Authentication/src",
+            "KickAss\\Toolbox\\": "src/Toolbox/src",
             "KickAss\\Moltin\\": "src/Moltin/src",
             "Example\\Project\\": "app/"
         }

--- a/doc/.env.template
+++ b/doc/.env.template
@@ -1,5 +1,6 @@
 ENV_DEBUG="true"
 ENV_TIMEZONE="Europe/Amsterdam"
+ENV_ENVIRONMENT="(develop|accept|production)"
 
 BRIDGE="moltin"
 MOLTIN_CLIENT_ID="YOUR_ID_HERE"

--- a/octocli
+++ b/octocli
@@ -7,6 +7,8 @@ require 'bootstrap/env.php';
 use Symfony\Component\Console\Application;
 
 use KickAss\Commerce\Product\Command\CacheCommand as ProductCacheCommand;
+use KickAss\Toolbox\Command\ProvisionEnvironmentCommand as EnvironmentCommand;
+
 
 $application = new Application("
      OCTOCLI
@@ -22,5 +24,6 @@ A tool with it's tenticles
   in everything KickAss");
 
 $application->add(new ProductCacheCommand());
+$application->add(new EnvironmentCommand());
 
 $application->run();

--- a/octocli
+++ b/octocli
@@ -8,7 +8,18 @@ use Symfony\Component\Console\Application;
 
 use KickAss\Commerce\Product\Command\CacheCommand as ProductCacheCommand;
 
-$application = new Application();
+$application = new Application("
+     OCTOCLI
+
+     -------
+     | @ @ |
+     -------
+      ).-.(
+     '/|||\\`
+       '|`    
+
+A tool with it's tenticles 
+  in everything KickAss");
 
 $application->add(new ProductCacheCommand());
 

--- a/src/Toolbox/composer.json
+++ b/src/Toolbox/composer.json
@@ -1,0 +1,10 @@
+{
+    "name": "kickasscommerce/toolbox",
+    "description": "CLI toold for application maintenance",
+    "type": "library",
+    "autoload": {
+        "psr-4": {
+            "KickAss\\Tollbox\\": "src/"
+        }
+    }
+}

--- a/src/Toolbox/src/Command/ProvisionEnvironmentCommand.php
+++ b/src/Toolbox/src/Command/ProvisionEnvironmentCommand.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace KickAss\Toolbox\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ProvisionEnvironmentCommand extends Command
+{
+    protected function configure()
+    {
+        $this
+            ->setName('toolbox:provision')
+            ->setDescription('Run basic commands to get your installation ready for ' . getenv('ENV_ENVIRONMENT'))
+            ->addArgument(
+                'branch',
+                InputArgument::OPTIONAL,
+                'which branch should we use, current by default'
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $branch = $input->getArgument('branch') ?? '$(git rev-parse --abbrev-ref HEAD)';
+
+        // set up the right branch
+        $gitCheckAndPull = shell_exec("git checkout {$branch} && git pull origin {$branch}");
+        $output->writeln($gitCheckAndPull);
+
+        // composer install
+        $composerInstall = shell_exec("composer install");
+        $output->writeln($composerInstall);
+    }
+}

--- a/src/Toolbox/src/Command/ProvisionEnvironmentCommand.php
+++ b/src/Toolbox/src/Command/ProvisionEnvironmentCommand.php
@@ -27,7 +27,7 @@ class ProvisionEnvironmentCommand extends Command
         $branch = $input->getArgument('branch') ?? '$(git rev-parse --abbrev-ref HEAD)';
 
         // set up the right branch
-        $gitCheckAndPull = shell_exec("git checkout {$branch} && git pull origin {$branch}");
+        $gitCheckAndPull = shell_exec("git fetch origin && git checkout {$branch} && git pull origin {$branch}");
         $output->writeln($gitCheckAndPull);
 
         // composer install


### PR DESCRIPTION
So, remember with Magento 2 how you have to run 6 or more commands in a specific order to make sure you have everything up and ready when starting to develop? 

Was thinking that it would be cool to have an easy command for that which switches branch, pulls it and composer installs it. Anything we might add in the future like running a database migration can go in here.