### PR TITLE
Stop the product repository knowing too much

### DIFF
--- a/src/Commerce/Product/Repository/Product.php
+++ b/src/Commerce/Product/Repository/Product.php
@@ -9,11 +9,12 @@ use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 class Product implements ProductInterface
 {
     /**
-     * @var \KickAss\Commerce\Application\ProductInterface
+     * @var ApplicationProductInterface
      */
     private $product;
+
     /**
-     * @var \Symfony\Component\Serializer\Normalizer\ObjectNormalizer
+     * @var ObjectNormalizer
      */
     private $normalizer;
 
@@ -40,7 +41,7 @@ class Product implements ProductInterface
     {
         $productInfo = $this->product->getProductItem($id);
 
-        return $this->populateProductRepository($productInfo['result']);
+        return $this->populateProductRepository($productInfo);
     }
 
     /**
@@ -58,10 +59,10 @@ class Product implements ProductInterface
 
     /**
      * @param array $productData
-     * @return \KickAss\Commerce\Product\Map\Product
+     * @return MapProduct
      * @throws \Symfony\Component\Serializer\Exception\UnexpectedValueException
      */
-    public function populateProductRepository($productData)
+    public function populateProductRepository(array $productData)
     {
         /** @var MapProduct $product */
         $product = $this->normalizer->denormalize($productData, MapProduct::class);
@@ -70,14 +71,14 @@ class Product implements ProductInterface
 
     /**
      * @param array $filters
-     * @return \KickAss\Commerce\Product\Map\Product[]
+     * @return MapProduct[]
      * @throws \Symfony\Component\Serializer\Exception\UnexpectedValueException
      */
     public function search(array $filters = array())
     {
         $productInfo = $this->product->getProductList($filters);
         $products = [];
-        foreach ($productInfo['result'] as $product) {
+        foreach ($productInfo as $product) {
             $products[] = $this->normalizer->denormalize($product, MapProduct::class);
         }
         return $products;

--- a/src/Commerce/Product/Repository/ProductInterface.php
+++ b/src/Commerce/Product/Repository/ProductInterface.php
@@ -2,24 +2,26 @@
 
 namespace KickAss\Commerce\Product\Repository;
 
+use \KickAss\Commerce\Product\Map\Product;
+
 interface ProductInterface
 {
     /**
      * @param int $id
-     * @return \KickAss\Commerce\Product\Map\Product
+     * @return Product
      */
     public function load($id);
 
     /**
      * @param array $filters
-     * @return array
+     * @return Product[]
      */
     public function search(array $filters = array());
 
     /**
      * @param string $attribute
      * @param string $value
-     * @return mixed
+     * @return Product
      */
     public function loadByAttribute(string $attribute, string $value);
 }

--- a/src/Moltin/src/Bridge/Moltin/Product.php
+++ b/src/Moltin/src/Bridge/Moltin/Product.php
@@ -13,7 +13,8 @@ class Product implements \KickAss\Commerce\Application\ProductInterface
      */
     public function getProductList(array $filter = [])
     {
-        return MoltinProduct::Search($filter);
+        $products = MoltinProduct::Search($filter);
+        return $products['result'];
     }
 
     /**
@@ -22,7 +23,8 @@ class Product implements \KickAss\Commerce\Application\ProductInterface
      */
     public function getProductItem(int $identifier)
     {
-        return MoltinProduct::Get($identifier);
+        $product = MoltinProduct::Get($identifier);
+        return $product['result'];
     }
 
     /**
@@ -41,14 +43,5 @@ class Product implements \KickAss\Commerce\Application\ProductInterface
         }
 
         throw new ProductException("Product not found");
-    }
-
-    /**
-     * @param array $terms
-     * @return array
-     */
-    public function getSearchResults(array $terms = array())
-    {
-        return MoltinProduct::Search($terms);
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I have removed the knowledge to the Moltin SDK array format from the Product Repository and into the Moltin bridge.

## Motivation and context

This fixes https://github.com/KickAssCommerce/KickAssCommerce/issues/10 and also will help us when building more bridges to other api based commerce systems.

## How has this been tested?

The frontend is working still!

## Screenshots (if appropriate)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [X] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [X] My pull request addresses exactly one patch/feature.
- [X] I have created a branch for this patch/feature.
- [X] Each individual commit in the pull request is meaningful.
- [X] I have added tests to cover my changes. - Well the test failed when I made half the change and works now I made the other half.
- [X] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
